### PR TITLE
Do not terminate the camera capturing when hiding.

### DIFF
--- a/src/gphoto-preview.c
+++ b/src/gphoto-preview.c
@@ -306,9 +306,6 @@ static void capture_show(void *vptr) {
 
 static void capture_hide(void *vptr) {
     struct preview_data *data = vptr;
-    if(data->source->active) {
-        capture_terminate(data);
-    }
 }
 
 static void *capture_create(obs_data_t *settings, obs_source_t *source){


### PR DESCRIPTION
This function is called e.g. when a scene is switched.
We do not want the camera to shut down at this time, since the next scene
may also include its image.

Furthermore, this fixes issue #12, though the underlying cause for the crash
still remains, namely that the terminate-funciton is called multiple times
without checking that the camera is still valid.